### PR TITLE
Fix vias and arcs not getting created and traces not cleared due to Python class id mismatch

### DIFF
--- a/placement.py
+++ b/placement.py
@@ -310,6 +310,7 @@ def copy_traces(
             trk.SetTopLayer(track.TopLayer())
             trk.SetBottomLayer(track.BottomLayer())
             trk.SetRemoveUnconnected(track.GetRemoveUnconnected())
+            trk.SetNet(board.FindNet(track.GetNetname()))
             # TODO: Check if we need to set zone layer overrides:
             # GetZoneLayerOverride(self, aLayer)
             # SetZoneLayerOverride(self, aLayer, aOverride)
@@ -333,6 +334,7 @@ def copy_traces(
         area = sheet.pcb.subboard.GetArea(area_id).Duplicate()
         board.Add(area)
         area.Move(transform.translate(pcbnew.VECTOR2I(0, 0)))
+        area.SetNet(board.FindNet(area.GetNetname()))
         mover(area)
         area_id += 1
 

--- a/placement.py
+++ b/placement.py
@@ -280,6 +280,9 @@ def clear_traces(board: pcbnew.BOARD, group: pcbnew.PCB_GROUP):
         if isinstance(item, pcbnew.PCB_TRACK):
             board.RemoveNative(item)
 
+        if isinstance(item, pcbnew.ZONE):
+            board.RemoveNative(item)
+
 
 def copy_traces(
     board: pcbnew.BOARD,
@@ -324,6 +327,14 @@ def copy_traces(
         # TODO: What other properties do we need to copy?
 
         mover(trk)
+
+    area_id = 0
+    while sheet.pcb.subboard.GetArea(area_id) is not None:
+        area = sheet.pcb.subboard.GetArea(area_id).Duplicate()
+        board.Add(area)
+        area.Move(transform.translate(pcbnew.VECTOR2I(0, 0)))
+        mover(area)
+        area_id += 1
 
     return errors
 

--- a/placement.py
+++ b/placement.py
@@ -278,7 +278,7 @@ def clear_traces(board: pcbnew.BOARD, group: pcbnew.PCB_GROUP):
 
     for item in group.GetItems():
         item_type = type(item).__name__
-        if (item_type == 'PCB_TRACK' or item_type == 'pcbnew.ZONE'):
+        if (item_type == 'PCB_TRACK' or item_type == 'ZONE' or item_type == 'PCB_VIA'):
             board.RemoveNative(item)
 
         # TODO: Do we need to remove areas too?

--- a/placement.py
+++ b/placement.py
@@ -284,6 +284,17 @@ def clear_traces(board: pcbnew.BOARD, group: pcbnew.PCB_GROUP):
             board.RemoveNative(item)
 
 
+def find_net_or_create(board: pcbnew.BOARD, net: pcbnew.NETINFO_ITEM):
+    existing_net = board.FindNet(net.GetNetname())
+    if existing_net:
+        return existing_net
+
+    nets = board.GetNetInfo()
+    net.SetNetCode(nets.GetNetCount())
+    nets.AppendNet(net)
+    return net
+
+
 def copy_traces(
     board: pcbnew.BOARD,
     sheet: SchSheet,
@@ -310,7 +321,7 @@ def copy_traces(
             trk.SetTopLayer(track.TopLayer())
             trk.SetBottomLayer(track.BottomLayer())
             trk.SetRemoveUnconnected(track.GetRemoveUnconnected())
-            trk.SetNet(board.FindNet(track.GetNetname()))
+            trk.SetNet(find_net_or_create(board, track.GetNet()))
             # TODO: Check if we need to set zone layer overrides:
             # GetZoneLayerOverride(self, aLayer)
             # SetZoneLayerOverride(self, aLayer, aOverride)
@@ -334,7 +345,7 @@ def copy_traces(
         area = sheet.pcb.subboard.GetArea(area_id).Duplicate()
         board.Add(area)
         area.Move(transform.translate(pcbnew.VECTOR2I(0, 0)))
-        area.SetNet(board.FindNet(area.GetNetname()))
+        area.SetNet(find_net_or_create(board, area.GetNet()))
         mover(area)
         area_id += 1
 

--- a/placement.py
+++ b/placement.py
@@ -284,9 +284,8 @@ def clear_traces(board: pcbnew.BOARD, group: pcbnew.PCB_GROUP):
             board.RemoveNative(item)
 
 
-def find_net_or_create(board: pcbnew.BOARD, net: pcbnew.NETINFO_ITEM):
-    existing_net = board.FindNet(net.GetNetname())
-    if existing_net:
+def find_or_set_net(board: pcbnew.BOARD, net: pcbnew.NETINFO_ITEM):
+    if existing_net := board.FindNet(net.GetNetname()):
         return existing_net
 
     nets = board.GetNetInfo()
@@ -321,7 +320,7 @@ def copy_traces(
             trk.SetTopLayer(track.TopLayer())
             trk.SetBottomLayer(track.BottomLayer())
             trk.SetRemoveUnconnected(track.GetRemoveUnconnected())
-            trk.SetNet(find_net_or_create(board, track.GetNet()))
+            trk.SetNet(find_or_set_net(board, track.GetNet()))
             # TODO: Check if we need to set zone layer overrides:
             # GetZoneLayerOverride(self, aLayer)
             # SetZoneLayerOverride(self, aLayer, aOverride)
@@ -345,7 +344,7 @@ def copy_traces(
         area = sheet.pcb.subboard.GetArea(area_id).Duplicate()
         board.Add(area)
         area.Move(transform.translate(pcbnew.VECTOR2I(0, 0)))
-        area.SetNet(find_net_or_create(board, area.GetNet()))
+        area.SetNet(find_or_set_net(board, area.GetNet()))
         mover(area)
         area_id += 1
 

--- a/placement.py
+++ b/placement.py
@@ -277,11 +277,10 @@ def clear_traces(board: pcbnew.BOARD, group: pcbnew.PCB_GROUP):
     # pointer type doesn't work in the Python bindings.
 
     for item in group.GetItems():
-        if isinstance(item, pcbnew.PCB_TRACK):
+        if isinstance(item, (pcbnew.PCB_TRACK, pcbnew.ZONE)):
             board.RemoveNative(item)
 
-        if isinstance(item, pcbnew.ZONE):
-            board.RemoveNative(item)
+        # TODO: Do we need to remove areas too?
 
 
 def find_or_set_net(board: pcbnew.BOARD, net: pcbnew.NETINFO_ITEM):
@@ -340,8 +339,8 @@ def copy_traces(
         mover(trk)
 
     area_id = 0
-    while sheet.pcb.subboard.GetArea(area_id) is not None:
-        area = sheet.pcb.subboard.GetArea(area_id).Duplicate()
+    while area_orig := sheet.pcb.subboard.GetArea(area_id):
+        area = area_orig.Duplicate()
         board.Add(area)
         area.Move(transform.translate(pcbnew.VECTOR2I(0, 0)))
         area.SetNet(find_or_set_net(board, area.GetNet()))

--- a/placement.py
+++ b/placement.py
@@ -299,7 +299,7 @@ def copy_traces(
         # logger.info(f"{track} {type(track)} {track.GetStart()} -> {track.GetEnd()}")
         if isinstance(track, pcbnew.PCB_ARC):
             trk = pcbnew.PCB_ARC(board)
-            trk.SetMid(track.GetMid())
+            trk.SetMid(transform.translate(track.GetMid()))
         elif isinstance(track, pcbnew.PCB_VIA):
             trk = pcbnew.PCB_VIA(board)
             trk.SetViaType(track.GetViaType())


### PR DESCRIPTION
Hello,
Here is a fix for an issue I am having on windows 10 with kicad 7.0.10. I noticed that the vias are not getting copied over, so after a little debugging it turned out that the class id for pcbnew.PCB_TRACK is not the same as for the track instance's class id itself.
I have no experience with python, so I don't know what is an elegant solution for this. If I understand well, the same module/class might refer to different modules/classes in Python, or it might be due to the SWIG binding, so I made a fallback on the track class' name. What system is this being developed on? Anyway, here is the patch.

# KiCad Version


```
Application: KiCad PCB Editor x64 on x64

Version: 7.0.10, release build

Libraries:
	wxWidgets 3.2.4
	FreeType 2.12.1
	HarfBuzz 8.2.1
	FontConfig 2.14.2

Platform: Windows 10 (build 19045), 64-bit edition, 64 bit, Little endian, wxMSW

	wxWidgets: 3.2.4 (wchar_t,wx containers)
	Boost: 1.83.0
	OCC: 7.7.1
	Curl: 8.4.0-DEV
	ngspice: 41
	Compiler: Visual C++ 1936 without C++ ABI

Build settings:
	KICAD_SPICE=ON

```