### PR TITLE
fix: footprint text rotation if not similar to footprint rotation

### DIFF
--- a/placement.py
+++ b/placement.py
@@ -130,11 +130,9 @@ class PositionTransform:
 
             # TODO: Set the flipped status
 
-            # Move the text:
+            # Move and rotate the text:
             dst.SetPosition(self.translate(src.GetPosition()))
-            # The rotation stacks with the rotation of the footprint, so we don't need to
-            # set the rotation here. TODO: Check this with a bunch of rotations.
-            # dst.SetTextAngle(new_rot)
+            dst.SetTextAngle(src.GetTextAngle())
 
         elif type(src) == pcbnew.FP_TEXT:
             # We have a source but no destination. We should eventually add support for


### PR DESCRIPTION
Hi @gauravmm,
we also stumbled upon a little bug. It can be reproduced easily: just rotate a footprint text separately from the footprint. Then, the rotation is not replicated. This PR fixes that 👍 