### PR TITLE
feat: small ui improvements

### DIFF
--- a/interface/DlgHPCBRun.py
+++ b/interface/DlgHPCBRun.py
@@ -81,13 +81,11 @@ class DlgHPCBRun(DlgHPCBRun_Base):
         sheets = []
         labels = {}
         for sheet in hD.root_sheet.tree_iter(skip_root=True):
-            # If the sheet has a PCB, mention it in the appropriate column:
-            row_text = sheet.human_name
-            if sheet.pcb is not None:
-                row_text = f"[{sheet.pcb.path.relative_to(hD.basedir).with_suffix('')}] {row_text}"
-                if not sheet.pcb.is_legal:
-                    row_text += " No Footprints!"
-            labels[sheet] = row_text
+            if sheet.pcb is None:
+                continue
+            labels[sheet] = f"[{sheet.pcb.path.relative_to(hD.basedir).with_suffix('')}] {sheet.human_name}"
+            if not sheet.pcb.is_legal:
+                labels[sheet] += " No Footprints!"
             sheets.append(sheet)
 
         # sort alphabetically

--- a/interface/DlgHPCBRun.py
+++ b/interface/DlgHPCBRun.py
@@ -11,6 +11,20 @@ from .DlgHPCBRun_Base import DlgHPCBRun_Base
 logger = logging.getLogger("hierpcb")
 
 
+def setItemPrefix(tree: wx.dataview.TreeListCtrl, item: wx.dataview.TreeListItem, prefix: str):
+    prefixes = ["✅", "❌"]
+    """Set the prefix of the item's text and remove the previous prefix if any (always separated by a space)."""
+    if prefix not in prefixes:
+        raise ValueError(f"Invalid prefix: {prefix}")
+    text = tree.GetItemText(item)
+    for p in prefixes:
+        text = text.replace(f"{p} ", "")
+    tree.SetItemText(item, f"{prefix} {text}")
+
+def setItemChecked(tree: wx.dataview.TreeListCtrl, item: wx.dataview.TreeListItem, checked: bool):
+    """Set the checked state of the item."""
+    setItemPrefix(tree, item, '✅' if checked else '❌')
+
 def set_checked_default(
     tree: wx.dataview.TreeListCtrl, sheet: SchSheet, ancestor_checked: bool = False
 ):
@@ -26,7 +40,7 @@ def set_checked_default(
             if not ancestor_checked:
                 sheet.checked = True
 
-        tree.SetItemBold(sheet.list_ref, sheet.checked)
+        setItemChecked(tree, sheet.list_ref, sheet.checked)
 
     # Recur on the children:
     for _, child in sorted(sheet.children.items()):
@@ -37,7 +51,7 @@ def apply_checked(tree: wx.dataview.TreeListCtrl, sheet: SchSheet):
     """Mutate the tree to reflect the checked state of the sheets."""
     # Skip nodes that don't have list refs:
     if sheet.list_ref:
-        tree.SetItemBold(sheet.list_ref, sheet.checked)
+        setItemChecked(tree, sheet.list_ref, sheet.checked)
     # Recur on the children:
     for _, child in sorted(sheet.children.items()):
         apply_checked(tree, child)
@@ -108,7 +122,7 @@ class DlgHPCBRun(DlgHPCBRun_Base):
         if is_checkable(self.treeApplyTo, sheet):
             if sheet.checked:
                 sheet.checked = False
-                self.treeApplyTo.SetItemBold(sheet.list_ref, sheet.checked)
+                setItemChecked(self.treeApplyTo, item, False)
             else:
                 # Check it and uncheck all descendants:
                 set_checked_default(self.treeApplyTo, sheet)


### PR DESCRIPTION
Hi @gauravmm,
here's three fixes we did to improve our user experience. If you like them, feel free to merge or just cherry-pick some changes 👍

- fdb84c460ddd52b1b12d1bdd7a93d840eb191c86: on macos with a FullHD screen it is difficult to see whether tree items are bold or not. Therefore, we used ✅ and ❌ to make that more clear.
- f185694cb10142c54f7908a53cda086bee3a514e: the list is now sorted alphabetically (human sorting) and the `.kicad_pcb` is hidden from the filenames
- 539888eb82e3a0f28fd1b5922f371299f5f53243: sheets without pcb files are now hidden