### PR TITLE
Remove Recursion (Uses Hruegars first  two UI changes)

### DIFF
--- a/src/hdata.py
+++ b/src/hdata.py
@@ -142,13 +142,6 @@ class SchSheet:
         # Recur on the rest in the child sheet.
         return self.children[cons].get(rest, create)
 
-    def tree_iter(self, skip_root=False):
-        """Iterate over the tree."""
-        if not skip_root:
-            yield self
-        for _, child in sorted(self.children.items()):
-            yield from child.tree_iter()
-
     def set_checked_default(self, ancestor_checked: bool = False):
         """Set the tree to its default state recursively."""
         self.checked = False
@@ -159,17 +152,10 @@ class SchSheet:
             if not ancestor_checked:
                 self.checked = True
 
-        # Recur on the children:
-        for child in self.children.values():
-            child.set_checked_default(child, self.checked or ancestor_checked)
-
     def cleanup_checked(self, ancestor_checked: bool = False):
         """Make sure that there are no paths from the root that include more than one checked sheet."""
         if ancestor_checked:
             self.checked = False
-        # Recur on the children:
-        for child in self.children.values():
-            child.set_checked_default(child, self.checked or ancestor_checked)
 
     @property
     def identifier(self) -> str:
@@ -217,7 +203,7 @@ class HierarchicalData:
             )
             subpcb.set_anchor_ref(anchor)
 
-        for sheet in self.root_sheet.tree_iter():
+        for sheet in self.root_sheet.children.values():
             sheet.checked = cfg.get("sheet", sheet.identifier, "checked", default=False)
         sheet.cleanup_checked()
 
@@ -232,7 +218,7 @@ class HierarchicalData:
                 value=subpcb.get_anchor_ref(),
             )
         cfg.clear("sheet")
-        for sheet in self.root_sheet.tree_iter():
+        for sheet in self.root_sheet.children.values():
             cfg.set("sheet", sheet.identifier, "checked", value=sheet.checked)
 
 

--- a/src/interface/DlgHPCBRun.py
+++ b/src/interface/DlgHPCBRun.py
@@ -185,3 +185,15 @@ class DlgHPCBRun(DlgHPCBRun_Base):
         """Submit the form."""
         # Mutate the tree structure and
         self.EndModal(wx.ID_OK)
+
+
+def humanSort(list, key=None):
+    '''Sort the given list of strings in the way that humans expect (e.g. "1" < "2" < "10"). Also support all string prefixes and sort those alphabetically like a1 < a11 < b3 < b20'''
+    import re
+    convert = lambda text: int(text) if text.isdigit() else text.lower()
+    alphanum_key = lambda key: [ convert(c) for c in re.split('([0-9]+)', key) ]
+    if key:
+        list.sort(key=lambda x: alphanum_key(key(x)))
+    else:
+        list.sort(key=alphanum_key)
+    return list

--- a/src/interface/DlgHPCBRun.py
+++ b/src/interface/DlgHPCBRun.py
@@ -11,6 +11,20 @@ from .DlgHPCBRun_Base import DlgHPCBRun_Base
 logger = logging.getLogger("hierpcb")
 
 
+def setItemPrefix(tree: wx.dataview.TreeListCtrl, item: wx.dataview.TreeListItem, prefix: str):
+    prefixes = ["✅", "❌"]
+    """Set the prefix of the item's text and remove the previous prefix if any (always separated by a space)."""
+    if prefix not in prefixes:
+        raise ValueError(f"Invalid prefix: {prefix}")
+    text = tree.GetItemText(item)
+    for p in prefixes:
+        text = text.replace(f"{p} ", "")
+    tree.SetItemText(item, f"{prefix} {text}")
+
+def setItemChecked(tree: wx.dataview.TreeListCtrl, item: wx.dataview.TreeListItem, checked: bool):
+    """Set the checked state of the item."""
+    setItemPrefix(tree, item, '✅' if checked else '❌')
+
 def set_checked_default(
     tree: wx.dataview.TreeListCtrl, sheet: SchSheet, ancestor_checked: bool = False
 ):
@@ -26,7 +40,7 @@ def set_checked_default(
             if not ancestor_checked:
                 sheet.checked = True
 
-        tree.SetItemBold(sheet.list_ref, sheet.checked)
+        setItemChecked(tree, sheet.list_ref, sheet.checked)
 
     # Recur on the children:
     for _, child in sorted(sheet.children.items()):
@@ -37,7 +51,7 @@ def apply_checked(tree: wx.dataview.TreeListCtrl, sheet: SchSheet):
     """Mutate the tree to reflect the checked state of the sheets."""
     # Skip nodes that don't have list refs:
     if sheet.list_ref:
-        tree.SetItemBold(sheet.list_ref, sheet.checked)
+        setItemChecked(tree, sheet.list_ref, sheet.checked)
     # Recur on the children:
     for _, child in sorted(sheet.children.items()):
         apply_checked(tree, child)
@@ -113,7 +127,7 @@ class DlgHPCBRun(DlgHPCBRun_Base):
         if is_checkable(self.treeApplyTo, sheet):
             if sheet.checked:
                 sheet.checked = False
-                self.treeApplyTo.SetItemBold(sheet.list_ref, sheet.checked)
+                setItemChecked(self.treeApplyTo, item, False)
             else:
                 # Check it and uncheck all descendants:
                 set_checked_default(self.treeApplyTo, sheet)

--- a/src/placement.py
+++ b/src/placement.py
@@ -207,7 +207,7 @@ def enforce_position(hd: HierarchicalData, board: pcbnew.BOARD):
     errors: List[ReportedError] = []
     groupman: GroupManager = GroupManager(board)
 
-    for sheet in hd.root_sheet.tree_iter():
+    for sheet in hd.root_sheet.children.values():
         if sheet.pcb and sheet.checked:
             # Check if the sub-PCB is legal:
             if not sheet.pcb.is_legal:


### PR DESCRIPTION
From my usage of the plugin, I don't see a need to be able to replicate a grandchild PCB from the root PCB. Any level of tree depth can be achieved by visiting the parent of said grandchild and working up the tree to the root.  

After modifying a grandchild PCB, you will most likely need to manually visit all it's ancestors anyways.

If you can come up with any use-cases where this would hurt functionality please let me know, but I feel like this simplifies use of the plugin.