### PR TITLE
Crash on field delete workaround

### DIFF
--- a/placement.py
+++ b/placement.py
@@ -351,21 +351,26 @@ def copy_footprint_fields(
     #       This is not a bug. The replicated pcbs are behaving the 
     #       exact same as the original would when rotated.
 
+    if len(sourceFootprint.GetFields()) != len(targetFootprint.GetFields())
+        logger.info("Number of footprint fields dont match")
+        return
+
     # Do any other field values need preserved?
     originalReference = targetFootprint.GetReference()
 
     # Remove Existing footprint fields
-    for existingField in targetFootprint.GetFields():
-        targetFootprint.RemoveNative(existingField)
-    # Add all the source fields and move them
-    for sourceField in sourceFootprint.GetFields():
-        newField = sourceField.CloneField()
-        newField.SetParent(targetFootprint)
-        
-        newField.SetPosition(transform.translate(sourceField.GetPosition()))
-        newField.Rotate(newField.GetPosition(), transform.orient(pcbnew.ANGLE_0))
+    for targetField in targetFootprint.GetFields():
+        sourceField = sourceFootprint.GetFieldByName(
+            targetField.GetName()
+        )
+        if not sourceField:
+            logger.info("Field not found by name")
+            continue
 
-        targetFootprint.AddField(newField)
+        targetField.SetPosition(transform.translate(sourceField.GetPosition()))
+        targetField.SetTextAngle(
+            transform.orient(sourceField.GetTextAngle())
+        )
 
     targetFootprint.SetReference(originalReference)
 


### PR DESCRIPTION
For some reason, Kicad seems to crash when footprint fields are deleted now. I had this problem and one other user in [this](https://github.com/gauravmm/HierarchicalPcb/issues/32) thread. As a workaround, It just moves and edits the fields instead of deleting and copying them.